### PR TITLE
Add GitHub Actions workflow for Docker image

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -40,5 +40,5 @@ jobs:
           tags: |
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
-          cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
-          cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:cache
+          cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:cache,mode=max

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -40,5 +40,3 @@ jobs:
           tags: |
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
-          cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:cache
-          cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:cache,mode=max

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -26,11 +26,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets._GITHUB_PAT }}
 
-      - name: Git lowercase repository name
-        id: repository-lowercase
+      - name: Git lowercase repository owner
+        id: repository-owner-lowercase
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ github.repository }}
+          string: ${{ github.repository_owner }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
@@ -38,5 +38,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
-            ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
+            ghcr.io/${{ steps.repository-owner-lowercase.outputs.lowercase }}/rvc-api:${{ github.ref_name }}
+            ghcr.io/${{ steps.repository-owner-lowercase.outputs.lowercase }}/rvc-api:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Prune Docker System
+        run: docker system prune -af
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -49,8 +49,8 @@ jobs:
           tags: |
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
-            cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
-            cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
+          cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest,mode=max
 
       - name: Check Disk Space on workflow failure
         if: failure()

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -49,6 +49,8 @@ jobs:
           tags: |
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
+            cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
+            cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest,mode=max
 
       - name: Check Disk Space on workflow failure
         if: failure()

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -6,8 +6,8 @@ on:
       - '*'
 
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
+  build-and-push:
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Check Disk Space after Checkout
         run: df -h
 
+      - name: Prune Docker System
+        run: docker system prune -af
+
+      - name: Check Disk Space after Prune Docker System
+        run: df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Prune Docker System
-        run: docker system prune -af
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -13,8 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Check Disk Space after Checkout
+        run: df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Check Disk Space after Set up Docker Buildx
+        run: df -h
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
@@ -37,3 +43,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
+
+      - name: Check Disk Space on workflow failure
+        if: failure()
+        run: df -h

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,33 @@
+name: Push Docker image to GitHub Container Registry
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets._GITHUB_PAT }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -23,11 +23,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets._GITHUB_PAT }}
 
+      - name: Git lowercase repository name
+        id: repository-lowercase
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:${{ github.ref_name }}
+            ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -13,20 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check Disk Space after Checkout
-        run: df -h
-
       - name: Prune Docker System
         run: docker system prune -af
 
-      - name: Check Disk Space after Prune Docker System
-        run: df -h
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Check Disk Space after Set up Docker Buildx
-        run: df -h
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
@@ -51,7 +42,3 @@ jobs:
             ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
           cache-from: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest
           cache-to: type=registry,ref=ghcr.io/${{ steps.repository-lowercase.outputs.lowercase }}:latest,mode=max
-
-      - name: Check Disk Space on workflow failure
-        if: failure()
-        run: df -h

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,14 @@ WORKDIR /app
 
 COPY ./pyproject.toml .
 
-RUN pip install "poetry==1.7.1" && \
+RUN pip install \
+      --no-cache-dir \
+      "poetry==1.7.1" && \
+    poetry config virtualenvs.create false && \
     poetry install \
       --no-interaction \
       --no-root && \
-    poetry cache clear --all . && \
-    rm -rf /root/.cache/pip
+    poetry cache clear --all .
 
 COPY ./rvc ./rvc
 COPY ./.env-docker ./.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /app
 RUN pip install "poetry==1.7.1"
 
 COPY ./pyproject.toml .
+COPY ./README.md .
 
 RUN poetry install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,9 @@ RUN pip install "poetry==1.7.1"
 
 COPY ./pyproject.toml .
 COPY ./README.md .
+COPY ./rvc ./rvc
 
 RUN poetry install
-
-COPY ./rvc ./rvc
 
 COPY ./.env-docker ./.env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:3.19.1 as assets
 
-RUN apk add --update \
-      bash \
-      git \
-      git-lfs
+RUN apk add \
+      --update \
+      --no-cache \
+        bash \
+        git \
+        git-lfs
 
 COPY --chmod=755 ./assets-download.sh /assets-download.sh
 
@@ -16,7 +18,8 @@ SHELL [ "/bin/bash", "-c" ]
 RUN apt update && \
     apt install -y \
       libsndfile1 \
-      libsndfile1-dev
+      libsndfile1-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=assets /assets /assets
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,12 @@ WORKDIR /app
 RUN pip install "poetry==1.7.1"
 
 COPY ./pyproject.toml .
-COPY ./README.md .
+
+RUN poetry install \
+      --no-interaction \
+      --no-root
+
 COPY ./rvc ./rvc
-
-RUN poetry install
-
 COPY ./.env-docker ./.env
 
 CMD [ "poetry", "run", "poe", "rvc-api" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,13 @@ COPY --from=assets /assets /assets
 
 WORKDIR /app
 
-RUN pip install "poetry==1.7.1"
-
 COPY ./pyproject.toml .
 
-RUN poetry install \
+RUN pip install "poetry==1.7.1" && \
+    poetry install \
       --no-interaction \
-      --no-root
+      --no-root && \
+    poetry cache purge --all
 
 COPY ./rvc ./rvc
 COPY ./.env-docker ./.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt update && \
     apt install -y \
       libsndfile1 \
       libsndfile1-dev && \
+    apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=assets /assets /assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install "poetry==1.7.1" && \
     poetry install \
       --no-interaction \
       --no-root && \
-    poetry cache purge --all && \
+    poetry cache clear --all . && \
     rm -rf /root/.cache/pip
 
 COPY ./rvc ./rvc

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN pip install "poetry==1.7.1" && \
     poetry install \
       --no-interaction \
       --no-root && \
-    poetry cache purge --all
+    poetry cache purge --all && \
+    rm -rf /root/.cache/pip
 
 COPY ./rvc ./rvc
 COPY ./.env-docker ./.env

--- a/assets-download.sh
+++ b/assets-download.sh
@@ -2,6 +2,12 @@
 #
 # Downloads required large files for RVC.
 
+function download() {
+  local path="$1"
+  echo "Downloading ${path}"
+  git lfs pull --include="${path}"
+}
+
 set -e
 
 REPO_FOLDER="VoiceConversionWebUI"
@@ -16,16 +22,18 @@ git clone https://huggingface.co/lj1995/VoiceConversionWebUI "${REPO_FOLDER}"
 
 pushd "${REPO_FOLDER}"
 
+git config advice.detachedHead false
+
 git checkout "${assets_commit_hash}"
 
 unset GIT_LFS_SKIP_SMUDGE
 unset GIT_CLONE_PROTECTION_ACTIVE
 
-git lfs pull --include="hubert_base.pt"
-git lfs pull --include="pretrained"
-git lfs pull --include="uvr5_weights"
-git lfs pull --include="rmvpe.pt"
-git lfs pull --include="rmvpe.onnx"
+download "hubert_base.pt"
+download "pretrained"
+download "uvr5_weights"
+download "rmvpe.pt"
+download "rmvpe.onnx"
 
 rm -rf .git
 

--- a/assets-download.sh
+++ b/assets-download.sh
@@ -27,16 +27,18 @@ git lfs pull --include="uvr5_weights"
 git lfs pull --include="rmvpe.pt"
 git lfs pull --include="rmvpe.onnx"
 
+rm -rf .git
+
 popd
 
 mkdir -p "${assets_dir}"
 
-cp "${REPO_FOLDER}/hubert_base.pt" "${assets_dir}/hubert_base.pt"
+mv "${REPO_FOLDER}/hubert_base.pt" "${assets_dir}/hubert_base.pt"
 
 mkdir -p "${assets_dir}/rmvpe"
 
-cp "${REPO_FOLDER}/rmvpe.pt" "${assets_dir}/rmvpe/rmvpe.pt"
-cp "${REPO_FOLDER}/rmvpe.onnx" "${assets_dir}/rmvpe/rmvpe.onnx"
+mv "${REPO_FOLDER}/rmvpe.pt" "${assets_dir}/rmvpe/rmvpe.pt"
+mv "${REPO_FOLDER}/rmvpe.onnx" "${assets_dir}/rmvpe/rmvpe.onnx"
 
-cp -r "${REPO_FOLDER}/pretrained" "${assets_dir}/pretrained"
-cp -r "${REPO_FOLDER}/uvr5_weights" "${assets_dir}/uvr5_weights"
+mv "${REPO_FOLDER}/pretrained" "${assets_dir}/pretrained"
+mv "${REPO_FOLDER}/uvr5_weights" "${assets_dir}/uvr5_weights"


### PR DESCRIPTION
Hi!

I've created a GitHub Actions workflow for building and pushing the RVC API Docker image. I originally did this for myself, but it might be helpful to others as well.

Additionally, I've optimized the Docker image size, reducing it from 6.19GB to 4.82GB, as it was barely fitting within the [limitations of GitHub-hosted Actions runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). 😅

Requirements for this to work:
1. [Create GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with `write:packages` scope.
2. Add GitHub PAT to secrets of repository:
   1. Got to the [settings](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion/settings/secrets/actions).
   2. Click **New repository secret**.
   3. Add GitHub PAT as **Secret**.
   4. Enter `_GITHUB_PAT` as **Name**.
3. Push Git tags to tigger workflow. 