### PR TITLE
Docker Fix dos unix malfunction in windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ RUN apk add \
       --no-cache \
         bash \
         git \
-        git-lfs
+        git-lfs\
+        dos2unix
 
 COPY --chmod=755 ./assets-download.sh /assets-download.sh
+
+#convert malformed line endings if cloned from Windows
+RUN dos2unix /assets-download.sh
 
 RUN /assets-download.sh 88e42f0cb3662ddc0dd263a4814206ce96d53214 assets
 


### PR DESCRIPTION
## Description

Docker image will not build when host is a Windows device. Problem is caused by malformed .sh script when the files are cloned to a windows device.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Windows cpu
- [x] Test Windows cuda
- [ ] Test Linux cpu (needs to be checked)
- [ ] Test Linux cuda (needs to be checked)
Testing procedure:
* Used the following rvc model to test the api (https://huggingface.co/sail-rvc/Donald_Trump__RVC_v2_)
* any valid speech file test.wav
For the non cuda tested using
```
docker run -it  -p 8000:8000 -v "{host_project_dir}/assets/weights:/weights" -v "{host_project_dir}/assets/indices:/indices" -v "{host_project_dir}/assets/audios:/audios" "rvc" 
```
After running this copy the model.pth to the {host_project_dir}/assets/weights folder and model.index to  {host_project_dir}/assets/indices. Finally copy your test.wav file to {host_project_dir}/assets/audios/test.wav
For the cuda test add --gpus=all to enable gpu usage.
```
docker run -it --gpus=all -p 8000:8000 -v "{host_project_dir}/assets/weights:/weights" -v "{host_project_dir}/assets/indices:/indices" -v "{host_project_dir}/assets/audios:/audios" "rvc"
```
Too save time I used the fastapi automatic documentation in it you have a button "try it" to quickely test if the inference api works.
Note for the audio path use the absolute path within the container to the audio file NOT the host path.

**Test Configuration**:
* OS: Windows 11
* Hardware: Intel cpu, nvidia quadro p2000
