### PR TITLE
Fix bug with Intel GPUs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ __pycache__/
 *$py.class
 
 .DS_Store
+test.py
+.gitignore
+input.wav
+output.wav

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,3 @@ __pycache__/
 *$py.class
 
 .DS_Store
-test.py
-.gitignore
-input.wav
-output.wav

--- a/rvc/lib/infer_pack/models.py
+++ b/rvc/lib/infer_pack/models.py
@@ -392,6 +392,12 @@ class SineGen(torch.nn.Module):
         output uv: tensor(batchsize=1, length, 1)
         """
         with torch.no_grad():
+            device = next(self.parameters(), None)
+            if device is not None:
+                device = device.device
+            else:
+                device = f0.device
+            align_corners = device.type != "xpu"
             f0 = f0[:, None].transpose(1, 2)
             f0_buf = torch.zeros(f0.shape[0], f0.shape[1], self.dim, device=f0.device)
             # fundamental component
@@ -412,7 +418,7 @@ class SineGen(torch.nn.Module):
                 tmp_over_one.transpose(2, 1),
                 scale_factor=float(upp),
                 mode="linear",
-                align_corners=True,
+                align_corners=align_corners,
             ).transpose(2, 1)
             rad_values = F.interpolate(
                 rad_values.transpose(2, 1), scale_factor=float(upp), mode="nearest"


### PR DESCRIPTION
Fixes a bug occurring on Intel GPUs in the file *rvc/lib/infer_pack/models.py* when the `align_corners` parameter is set to **True**.

This fix dynamically sets `align_corners` to **False** when the model is loaded on an **xpu** device and **True** otherwise.